### PR TITLE
`.window` margin quick fix

### DIFF
--- a/Portfolio/task/src/style.css
+++ b/Portfolio/task/src/style.css
@@ -186,12 +186,12 @@ footer{
 .window{
     display: none;
     position: fixed;
-    margin:0;
+    margin:0 !important;
     z-index: 1;
     left: 0;
     top: 0;
-    width: 100%;
-    height: 100%;
+    width: 100% !important;
+    height: 100% !important;
     background-color: rgb(0,0,0);
     background-color: rgba(0,0,0,0.4);
 }


### PR DESCRIPTION
This is a quick fix and not a fancy solution.

In the original stylesheet the window had 2% horizontal margins because of the `.portfolio-item div` styles. The best solution probably involves using different CSS selectors so it never happens again.